### PR TITLE
Adding density-setting as a configurable parameter

### DIFF
--- a/js/components/authoring.js
+++ b/js/components/authoring.js
@@ -6,6 +6,7 @@ import presets from '../presets'
 import ccLogo from '../../images/cc-logo.png'
 import ccLogoSmall from '../../images/cc-logo-small.png'
 import SortableDensities from './sortable-densities'
+import { getURLParam } from '../utils'
 
 import '../../css/authoring.less'
 
@@ -46,24 +47,21 @@ export default class Authoring extends PureComponent {
       takeSnapshot()
       this.setStep3()
     } else if (step === 3) {
-      takeSnapshot()
-      setOption('interaction', 'none')
-      setOption('selectableInteractions', [])
-      setOption('colormap', 'plate')
-      this.setState({step: 4})
+      if (config.densityStepEnabled) {
+        takeSnapshot()
+        setOption('interaction', 'none')
+        setOption('selectableInteractions', [])
+        setOption('colormap', 'plate')
+        this.setState({step: 4})
+      } else {
+        this.endAuthoring()
+      }
     } else if (step === 4) {
       const { setDensities } = this.props
       setDensities(this.state.intermediateDensities)
       setOption('colormap', 'topo')
 
-      setOption('authoring', false)
-      setOption('playing', true)
-      setOption('interaction', 'none')
-      setOption('colormap', config.colormap)
-      setOption('renderBoundaries', config.renderBoundaries)
-      setOption('renderForces', config.renderForces)
-      setOption('selectableInteractions', config.selectableInteractions)
-      this.setState({step: 5})
+      this.endAuthoring()
     }
   }
 
@@ -117,6 +115,18 @@ export default class Authoring extends PureComponent {
     setOption('selectableInteractions', [ 'force', 'none' ])
     setOption('colormap', 'topo')
     this.setState({step: 3})
+  }
+
+  endAuthoring () {
+    const { setOption } = this.props
+    setOption('authoring', false)
+    setOption('playing', true)
+    setOption('interaction', 'none')
+    setOption('colormap', config.colormap)
+    setOption('renderBoundaries', config.renderBoundaries)
+    setOption('renderForces', config.renderForces)
+    setOption('selectableInteractions', config.selectableInteractions)
+    this.setState({step: 5})
   }
 
   renderPreset (presetInfo) {
@@ -180,9 +190,14 @@ export default class Authoring extends PureComponent {
           <div className='divider' />
           { this.renderStep(3) }
           { this.renderInfo(3, 'Assign forces to plates') }
-          <div className='divider' />
-          { this.renderStep(4) }
-          { this.renderInfo(4, 'Order plates by density') }
+          {
+            config.densityStepEnabled &&
+              [
+                <div className='divider' />,
+                this.renderStep(4),
+                this.renderInfo(4, 'Order plates by density')
+              ]
+          }
           <div className='divider last' />
           <Button primary raised label={'back'} disabled={this.buttonDisabled} onClick={this.handleBackButtonClick} />
           <Button primary raised label={this.nextButtonLabel} disabled={this.buttonDisabled} onClick={this.handleNextButtonClick} />

--- a/js/config.js
+++ b/js/config.js
@@ -32,6 +32,9 @@ const DEFAULT_CONFIG = {
   optimizedCollisions: true,
   // Smoothing of cross section data. At this moment mainly affects oceanic floor and subducting areas.
   smoothCrossSection: true,
+  // Allows users to order plates by density in authoring.
+  // Usually it is overwritten using URL param: densityStepEnabled=true.
+  densityStepEnabled: false,
   // Density affects plate's inertia tensor.
   oceanDensity: 1,
   continentDensity: 3,


### PR DESCRIPTION
Density-setting is now hidden unless the URL parameter 'setDensities' is passed. This means conditionally hiding the step in the bottom bar, and skipping it after step 3. I held off on introducing an elegant way to hide additional steps, but if we added a second configurable step it's probably worth looking into.