### PR TITLE
Add reset camera buttons for the main view and the cross section view

### DIFF
--- a/css/cross-section-3d.less
+++ b/css/cross-section-3d.less
@@ -1,0 +1,10 @@
+.cross-section-3d-view {
+  position: relative;
+
+  .camera-reset {
+    color: white !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}

--- a/css/plates.less
+++ b/css/plates.less
@@ -46,4 +46,11 @@
     font-size: 20px;
     text-shadow: 1px 1px 2px #484848;
   }
+
+  .camera-reset {
+    color: white !important;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 }

--- a/css/react-toolbox-theme.less
+++ b/css/react-toolbox-theme.less
@@ -24,3 +24,18 @@
     font-size: 35px;
   }
 }
+
+.small-button {
+  font-size: 10px;
+  text-shadow: 2px 2px 5px #000;
+  height: auto;
+
+  .label {
+    line-height: 10px;
+  }
+
+  .material-icons {
+    font-size: 30px;
+  }
+}
+

--- a/js/components/cross-section-3d.js
+++ b/js/components/cross-section-3d.js
@@ -1,26 +1,56 @@
 import React, { PureComponent } from 'react'
 import CrossSection3DView from '../plates-view/cross-section-3d'
+import SmallButton from './small-button'
+
+import '../../css/cross-section-3d.less'
 
 export default class CrossSection3D extends PureComponent {
+  constructor (props) {
+    super(props)
+    this.state = {
+      showCameraResetButton: false
+    }
+    this.onCameraChange = this.onCameraChange.bind(this)
+    this.resetCamera = this.resetCamera.bind(this)
+
+    this.view = new CrossSection3DView(this.viewProps)
+  }
+
+  get viewProps () {
+    return Object.assign({}, this.props, { onCameraChange: this.onCameraChange })
+  }
+
   componentDidMount () {
-    this.view = new CrossSection3DView()
     this.view3dContainer.appendChild(this.view.domElement)
   }
 
-  componentDidUpdate (prevProps) {
-    const { data, swapped } = this.props
-    if (data !== prevProps.data || swapped !== prevProps.swapped) {
-      this.view.setCrossSectionData(data, swapped)
-    }
+  componentDidUpdate () {
+    this.view.setProps(this.viewProps)
   }
 
   componentWillUnmount () {
     this.view.dispose()
   }
 
+  onCameraChange () {
+    this.setState({ showCameraResetButton: true })
+  }
+
+  resetCamera () {
+    this.view.resetCamera()
+    this.setState({ showCameraResetButton: false })
+  }
+
   render () {
+    const { showCameraResetButton } = this.state
     return (
-      <div className='cross-section-3d-view' ref={(c) => { this.view3dContainer = c }} />
+      <div className='cross-section-3d-view'>
+        <div ref={(c) => { this.view3dContainer = c }} />
+        {
+          showCameraResetButton &&
+          <SmallButton className='camera-reset' onClick={this.resetCamera} icon='settings_backup_restore' label='Reset camera' />
+        }
+      </div>
     )
   }
 }

--- a/js/components/plates.js
+++ b/js/components/plates.js
@@ -7,6 +7,7 @@ import InteractionSelector from './interaction-selector'
 import CrossSection, { CROSS_SECTION_TRANSITION_LENGTH } from './cross-section'
 import ModelProxy from '../plates-proxy/model-proxy'
 import View3D from '../plates-view/view-3d'
+import SmallButton from './small-button'
 import InteractionsManager from '../plates-interactions/interactions-manager'
 import { getImageData } from '../utils'
 import { shouldSwapDirection, getCrossSectionRectangle } from '../plates-model/cross-section-utils'
@@ -29,16 +30,6 @@ function getWorkerProps (state) {
     props[propName] = state[propName]
   })
   return props
-}
-
-// Return the whole state. It doesn't make sense to filter properties at this point, as View3D compares values anyway.
-function getView3DProps (state) {
-  return state
-}
-
-// See above, the same situation.
-function getInteractionProps (state) {
-  return state
 }
 
 // Main component that orchestrates simulation progress and view updates.
@@ -70,7 +61,8 @@ export default class Plates extends PureComponent {
       renderLatLongLines: config.renderLatLongLines,
       snapshotAvailable: false,
       plateDensities: {},
-      plateColors: {}
+      plateColors: {},
+      showCameraResetButton: false
     }
     // State that doesn't need to trigger React rendering (but e.g. canvas update).
     // It's kept separately for performance reasons.
@@ -88,9 +80,9 @@ export default class Plates extends PureComponent {
     // It's updated by messages coming from model worker where real calculations are happening.
     this.modelProxy = new ModelProxy()
     // 3D rendering.
-    this.view3d = new View3D(getView3DProps(this.completeState()))
+    this.view3d = new View3D(this.getView3DProps(this.completeState()))
     // User interactions, e.g. cross section drawing, force assignment and so on.
-    this.interactions = new InteractionsManager(this.view3d, getInteractionProps(this.completeState()))
+    this.interactions = new InteractionsManager(this.view3d, this.completeState())
 
     this.setupEventListeners()
 
@@ -109,6 +101,8 @@ export default class Plates extends PureComponent {
     this.restoreSnapshot = this.restoreSnapshot.bind(this)
     this.restoreInitialSnapshot = this.restoreInitialSnapshot.bind(this)
     this.handleResize = this.handleResize.bind(this)
+    this.handleCameraChange = this.handleCameraChange.bind(this)
+    this.resetCamera = this.resetCamera.bind(this)
     window.addEventListener('resize', this.handleResize)
 
     window.p = this
@@ -144,6 +138,11 @@ export default class Plates extends PureComponent {
     const prevCompleteState = this.completeState()
     Object.assign(this.nonReactState, newState)
     this.handleStateUpdate(prevCompleteState)
+  }
+
+  getView3DProps (state) {
+    // Return the whole state. It doesn't make sense to filter properties at this point, as View3D compares values anyway.
+    return Object.assign({}, state, { onCameraChange: this.handleCameraChange })
   }
 
   componentDidMount () {
@@ -245,8 +244,8 @@ export default class Plates extends PureComponent {
     }
     // Passing new properties to View3d and InteractionsManager is cheap on the other hand.
     // Also, those classes will calculate what has changed themselves and they will update only necessary elements.
-    this.view3d.setProps(getView3DProps(state))
-    this.interactions.setProps(getInteractionProps(state))
+    this.view3d.setProps(this.getView3DProps(state))
+    this.interactions.setProps(state)
   }
 
   handleDataFromWorker (data) {
@@ -305,6 +304,15 @@ export default class Plates extends PureComponent {
     this.view3d.resize(this.view3dContainer)
     const padding = 20
     this.setNonReactState({screenWidth: window.innerWidth - padding})
+  }
+
+  handleCameraChange () {
+    this.setState({ showCameraResetButton: true })
+  }
+
+  resetCamera () {
+    this.view3d.resetCamera()
+    this.setState({ showCameraResetButton: false })
   }
 
   loadModel (presetName) {
@@ -400,7 +408,7 @@ export default class Plates extends PureComponent {
 
   render () {
     const { authoring, modelState, showCrossSectionView, crossSectionOutput, stepsPerSecond, selectableInteractions,
-            interaction, crossSectionSwapped } = this.completeState()
+            interaction, crossSectionSwapped, showCameraResetButton } = this.completeState()
 
     return (
       <div className='plates'>
@@ -414,6 +422,10 @@ export default class Plates extends PureComponent {
             </div>
           }
         </div>
+        {
+          showCameraResetButton &&
+          <SmallButton className='camera-reset' onClick={this.resetCamera} icon='settings_backup_restore' label='Reset camera' />
+        }
         {
           stepsPerSecond > 0 &&
           <div className='benchmark'>FPS: {stepsPerSecond.toFixed(2)}</div>

--- a/js/components/small-button.js
+++ b/js/components/small-button.js
@@ -1,0 +1,17 @@
+import React, { PureComponent } from 'react'
+import FontIcon from 'react-toolbox/lib/font_icon'
+import { Button } from 'react-toolbox/lib/button'
+
+import '../../css/react-toolbox-theme.less'
+
+export default class SmallButton extends PureComponent {
+  render () {
+    const { className, label, icon, onClick } = this.props
+    return (
+      <Button className={`small-button ${className}`} onClick={onClick}>
+        <FontIcon value={icon} />
+        <div className='label'>{ label }</div>
+      </Button>
+    )
+  }
+}

--- a/js/plates-view/view-3d.js
+++ b/js/plates-view/view-3d.js
@@ -33,6 +33,13 @@ export default class View3D {
     this.props = {}
     this.setProps(props)
 
+    this.controls.addEventListener('change', () => {
+      const { onCameraChange } = this.props
+      if (onCameraChange) {
+        onCameraChange()
+      }
+    })
+
     this.render()
   }
 
@@ -54,8 +61,8 @@ export default class View3D {
     this.scene = new THREE.Scene()
 
     this.camera = new THREE.PerspectiveCamera(33, size.width / size.height, 0.1, 100)
-    this.camera.position.set(4.5, 0, 0)
     this.camera.lookAt(new THREE.Vector3(0, 0, 0))
+    this.setInitialCameraPos()
     this.scene.add(this.camera)
 
     this.controls = new THREE.OrbitControls(this.camera, this.renderer.domElement)
@@ -69,6 +76,15 @@ export default class View3D {
     this.scene.add(new THREE.HemisphereLight(0xC6C2B6, 0x3A403B, 0.75))
     this.light = new THREE.PointLight(0xffffff, 0.3)
     this.scene.add(this.light)
+  }
+
+  setInitialCameraPos () {
+    this.camera.position.set(4.5, 0, 0)
+  }
+
+  resetCamera () {
+    this.setInitialCameraPos()
+    this.controls.update()
   }
 
   addStaticMantle () {
@@ -173,7 +189,6 @@ export default class View3D {
 
   render () {
     window.requestAnimationFrame(this.render)
-    this.controls.update()
     this.light.position.copy(this.camera.position)
     this.renderer.render(this.scene, this.camera)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11420,6 +11420,18 @@
         "prop-types": "15.6.0"
       }
     },
+    "react-sortable-hoc": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/react-sortable-hoc/-/react-sortable-hoc-0.6.8.tgz",
+      "integrity": "sha512-sUUAtNdV84AKZ2o+F5lVOOFWcyWG6aGDkNFgHoieB1zFLeWLWENkix06asPS4/GhigfuRh06aZix1j3Qx8+NSQ==",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "prop-types": "15.6.0"
+      }
+    },
     "react-style-proptype": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-style-proptype/-/react-style-proptype-3.0.0.tgz",


### PR DESCRIPTION
This PR adds reset camera buttons for the main view and the cross-section view.

I was going back and forth and I wasn't sure if we should keep the state of the cross-section camera reset in the main component or in the CrossSection3D. I implemented both and decided the latter makes more sense. First, it's pretty UI-specific state and I don't think that it's crucial for the app to know it (even if we used Redux or MobX). Second, `CrossSection3D` already contains camera-related state in the canvas views. So, I think that self-contained component makes more sense.

Also, I think that probably it would be nice to refactor `Plates` component and separate out main 3D view component, so it's similar to the `CrossSection` component.