### PR TITLE
Make authoring steps fully configurable

### DIFF
--- a/css/authoring.less
+++ b/css/authoring.less
@@ -43,6 +43,12 @@
       margin: 0 10px;
     }
 
+    .step {
+      display: flex;
+      flex: 1 1 auto;
+      align-items: center;
+    }
+
     .divider {
       display: inline-block;
       border-top: 1px solid black;
@@ -88,7 +94,6 @@
       }
     }
 
-
     .cc-logo-large, .cc-logo-small {
       height: 46px;
       margin: 0 5px 0 10px;
@@ -130,7 +135,7 @@
     }
   }
 
-  .step-1-plates {
+  .step-plates {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -167,7 +172,7 @@
     }
   }
 
-  .step-4-plates {
+  .step-densities {
     display: flex;
     flex-direction: column;
     align-items: start;

--- a/js/components/plates.js
+++ b/js/components/plates.js
@@ -254,6 +254,10 @@ export default class Plates extends PureComponent {
     const { debugMarker } = this.nonReactState
     if (modelState === 'loading') {
       this.setState({modelState: 'loaded'})
+      if (this._modelLoadedCallback) {
+        this._modelLoadedCallback()
+        this._modelLoadedCallback = null
+      }
     }
     if (data.crossSection) {
       this.setState({crossSectionOutput: data.crossSection})
@@ -307,7 +311,7 @@ export default class Plates extends PureComponent {
     this.setNonReactState({screenWidth: window.innerWidth - padding})
   }
 
-  loadModel (presetName) {
+  loadModel (presetName, callback) {
     this.setState({modelState: 'loading'})
     const preset = presets[presetName]
     getImageData(preset.img, imgData => {
@@ -318,6 +322,7 @@ export default class Plates extends PureComponent {
         props: getWorkerProps(this.completeState())
       })
     })
+    this._modelLoadedCallback = callback
   }
 
   unloadModel () {

--- a/js/config.js
+++ b/js/config.js
@@ -4,6 +4,7 @@ const DEFAULT_CONFIG = {
   // Authoring mode that lets user pick a planet layout and put continents on them.
   // Usually it is overwritten using URL param: authoring=true.
   authoring: false,
+  authoringSteps: ['presets', 'continents', 'forces', 'densities'],
   // One of the cases defined in presets.js file that will be loaded automatically.
   // Usually it is overwritten using URL param: preset=subduction.
   preset: null,
@@ -70,12 +71,20 @@ const DEFAULT_CONFIG = {
 
 const urlConfig = {}
 
+function isArray (value) {
+  return typeof value === 'string' && value.match(/^\[.*\]$/)
+}
+
 Object.keys(DEFAULT_CONFIG).forEach((key) => {
   const urlValue = getURLParam(key)
   if (urlValue === 'true') {
     urlConfig[key] = true
   } else if (urlValue === 'false') {
     urlConfig[key] = false
+  } else if (isArray(urlValue)) {
+    // Array can be provided in URL using following format:
+    // &parameter=[value1,value2,value3]
+    urlConfig[key] = urlValue.substring(1, urlValue.length - 1).split(',')
   } else if (urlValue !== null && !isNaN(urlValue)) {
     // !isNaN(string) means isNumber(string).
     urlConfig[key] = parseFloat(urlValue)

--- a/js/plates-model/model-worker.js
+++ b/js/plates-model/model-worker.js
@@ -104,7 +104,6 @@ onmessage = function modelWorkerMsgHandler (event) {
     let storedModel = labeledSnapshots[data.label]
     if (storedModel) {
       self.m = model = Model.deserialize(storedModel)
-      delete labeledSnapshots[data.label]
     }
   }
   forceRecalcOutput = true


### PR DESCRIPTION
PR simplifies authoring component and makes it fully customizable. No more hardcoded step numbers.

There's a new config param: `authoringSteps`. It can be overwritten using URL, e.g.:
- http://models-resources.concord.org/plate-tectonics-3d/branch/flexible-authoring/index.html?authoring=true&authoringSteps=[presets,continents]
- http://models-resources.concord.org/plate-tectonics-3d/branch/flexible-authoring/index.html?authoring=true&authoringSteps=[presets,forces,densities]

I used `[a,b,c]` syntax, as it seems pretty compact and easy to serialize and deserialize. I think regexp is strict enough to avoid problems in practice. Using typical `parameter[]=a&paramter[]=b&parameter[]=c` will be more annoying if you want to define it by hand (+ more annoying to deserialize).

There'll be more changes to the authoring component soon, as I'm trying to make it work together with `preset` parameter (so you can preload model instead of picking one). And it'll work exactly the same way with `modelId` when it's ready.

UPDATE:
I've added new commit to this PR which ensures that authoring mode can be used with preset parameter too. It means we can combine authoring and existing model. I've also made sure that it'll support `modelId` parameter when it's implemented (but we'll need to double check it). Demo:
http://models-resources.concord.org/plate-tectonics-3d/branch/flexible-authoring/index.html?authoring=true&preset=subduction&authoringSteps=[continents,densities]