### PR TITLE
Making drag interface on density sorter more obvious

### DIFF
--- a/css/planet-wizard.less
+++ b/css/planet-wizard.less
@@ -178,5 +178,13 @@
     align-items: start;
     justify-content: center;
     margin-left: 13%;
+
+    .helper-text {
+      width: 200px;
+      text-align: center;
+      margin-left: -33px;
+      margin-top: 10px;
+      font-size: 20px;
+    }
   }
 }

--- a/css/sortable-densities.less
+++ b/css/sortable-densities.less
@@ -1,10 +1,13 @@
 .density-button-container {
-  cursor: pointer;
   border: 1px solid black;
   pointer-events: auto;
+  cursor: row-resize;
 
   .shading-box {
     background-color: transparent;
+    display: flex;
+    align-items: center;
+    height: 70px;
   }
 
   .shading-box:hover {
@@ -14,6 +17,7 @@
 
 .densities {
   text-align: center;
+  width: 140px;
 
   ul {
     list-style-type: none;
@@ -31,4 +35,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.hamburger-menu {
+  color: white;
+  margin-left: 7px;
 }

--- a/js/components/sortable-densities.js
+++ b/js/components/sortable-densities.js
@@ -1,6 +1,7 @@
 import React, {Component} from 'react'
-import {SortableContainer, SortableElement, arrayMove} from 'react-sortable-hoc'
+import {SortableContainer, SortableElement, SortableHandle, arrayMove} from 'react-sortable-hoc'
 import { hsv } from 'd3-hsv'
+import FontIcon from 'react-toolbox/lib/font_icon'
 
 import '../../css/sortable-densities.less'
 
@@ -9,10 +10,15 @@ function hsvToBackground (hsvColor) {
   return {backgroundColor: 'rgb(' + Math.floor(rgb.r) + ', ' + Math.floor(rgb.g) + ', ' + Math.floor(rgb.b) + ')'}
 }
 
+const DragHandle = SortableHandle(() => <FontIcon value='menu' className='hamburger-menu'/>)
+
 const SortableItem = SortableElement(({plateInfo}) =>
   <li className='density-button-container' style={hsvToBackground(plateInfo.color)}>
     <div className='shading-box'>
-      <div className='density-button'> {plateInfo.label} </div>
+      <DragHandle />
+      <div className='density-button'> 
+        {plateInfo.label} 
+      </div>
     </div>
   </li>
 )
@@ -67,10 +73,13 @@ export default class SortableDensites extends Component {
   }
   render () {
     return (
-      <div className='densities'>
-        LOW
-        <SortableList plateInfos={this.state.plateInfos} onSortEnd={this.onSortEnd} />
-        HIGH
+      <div>
+        <div className='densities'>
+          LOW
+          <SortableList plateInfos={this.state.plateInfos} onSortEnd={this.onSortEnd} useDragHandle={false}/>
+          HIGH
+        </div>
+        <div className='helper-text'>Click and drag to reorder the plate density.</div>
       </div>
     )
   }


### PR DESCRIPTION
@pjanik, re: the discussion [here](https://www.pivotaltracker.com/story/show/152289874), these are the changes I made to improve the UI of the density picker. Like Amy pointed out, this doesn't do much in terms of scaling on different devices, but I'm not sure the best way to handle that. In Geniverse, we just applied a scale factor on top of the whole page, but I realize you've made GEODE more responsive, so I'm curious what your thoughts are.

Specifically, the changes are: adding a hamburger menu and changing cursor to indicate drag-ability. Also adding helper text.