### PR TITLE
Enforce relative motion between plates and break big plates into smaller chunks

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -52,13 +52,17 @@ const DEFAULT_CONFIG = {
   // Width of the area around continent which acts as it's bumper / buffer. When this area is about to subduct,
   // drag forces will be applied to stop relative motion of the plates and prevent subduction of the neighbouring continent.
   continentBufferWidth: 750,
+  // Keeps model running. When all the plates reach the point when they move in the same direction, with the same speed,
+  // model will add some random forces and divide big plates (see minSizeRatioForDivision).
+  enforceRelativeMotion: true,
+  // Divide plates that occupy more than X of the planet area.
+  minSizeRatioForDivision: 0.65,
   // Rendering:
   colormap: 'topo', // 'topo' or 'plate'
   // Defines interaction that can be selected using top bar.
   selectableInteractions: [ 'crossSection', 'force', 'none' ],
   wireframe: false,
   renderBoundaries: false,
-  renderAdjacentFields: false,
   renderVelocities: true,
   renderForces: false,
   renderEulerPoles: false,

--- a/js/plates-model/add-relative-motion.js
+++ b/js/plates-model/add-relative-motion.js
@@ -1,0 +1,39 @@
+import * as THREE from 'three'
+
+function randomVec3 () {
+  return new THREE.Vector3(Math.random(), Math.random(), Math.random())
+}
+
+function removeDraggingFields (plates) {
+  const platesCount = plates.length
+  for (let i = platesCount - 1; i >= 0; i -= 1) {
+    const bottomPlate = plates[i]
+    bottomPlate.forEachField(bottomField => {
+      if (!bottomField.draggingPlate) {
+        return
+      }
+      for (let j = i - 1; j >= 0; j -= 1) {
+        const topPlate = plates[j]
+        const topField = topPlate.fieldAtAbsolutePos(bottomField.absolutePos)
+        if (topField) {
+          bottomPlate.deleteField(bottomField.id)
+          return
+        }
+      }
+    })
+  }
+}
+
+export default function addRelativeMotion (plates) {
+  // Remove fields that cause drag force and add some random hot spots.
+  removeDraggingFields(plates)
+  for (let plate of plates) {
+    plate.angularVelocity.setLength(plate.angularSpeed * 0.5)
+    const fields = Array.from(plate.fields.values())
+    const randomField = fields[Math.floor(fields.length * Math.random())]
+    const pos = randomField.absolutePos.clone().normalize()
+    // .cross() ensures that force vector is perpendicular to the earth surface.
+    const force = pos.clone().cross(randomVec3()).setLength(2)
+    plate.setHotSpot(pos, force)
+  }
+}

--- a/js/plates-model/divide-plate.js
+++ b/js/plates-model/divide-plate.js
@@ -1,0 +1,41 @@
+import Plate from './plate'
+
+const MIN_SIZE = 100 // fields
+
+function getBoundaryField (plate) {
+  const adjField = plate.adjacentFields.values().next().value
+  // Some neighbours of plate adjacent field is a boundary field. Pick any.
+  for (let neighborId of adjField.adjacentFields) {
+    if (plate.fields.has(neighborId)) {
+      return plate.fields.get(neighborId)
+    }
+  }
+}
+
+export default function dividePlate (plate) {
+  if (plate.size < MIN_SIZE) {
+    return null
+  }
+  const startField = getBoundaryField(plate)
+  const visited = { [startField.id]: true }
+  const queue = [ startField ]
+  const halfPlateSize = plate.size * 0.5
+
+  const newPlate = new Plate({ color: plate.baseColor, density: plate.density })
+  newPlate.quaternion.copy(plate.quaternion)
+  newPlate.angularVelocity.copy(plate.angularVelocity)
+
+  while (queue.length > 0 && newPlate.size < halfPlateSize) {
+    const field = queue.shift()
+    field.forEachNeighbour(adjField => {
+      if (!visited[adjField.id]) {
+        queue.push(adjField)
+        visited[adjField.id] = true
+      }
+    })
+    plate.deleteField(field.id)
+    newPlate.addExistingField(field)
+  }
+
+  return newPlate
+}

--- a/js/plates-model/model-output.js
+++ b/js/plates-model/model-output.js
@@ -21,28 +21,24 @@ function plateOutput (plate, props, stepIdx, forcedUpdate) {
   result.id = plate.id
   result.quaternion = plate.quaternion
   result.angularVelocity = plate.angularVelocity
-  if (stepIdx < 2) {
-    // Those properties are necessary only when proxy models are initialized, they don't change later.
-    // stepIdx < 2 as it can be equal to 0 or 1, depending if model is playing or not.
-    result.baseColor = plate.baseColor
-    result.density = plate.density
-  }
+  result.baseColor = plate.baseColor
+  result.density = plate.density
   if (props.renderHotSpots) {
     result.hotSpot = plate.hotSpot
   }
   if (forcedUpdate || shouldUpdate('fields', stepIdx)) {
     result.fields = {
-      id: new Uint32Array(plate.fields.size),
-      elevation: new Float32Array(plate.fields.size)
+      id: new Uint32Array(plate.size),
+      elevation: new Float32Array(plate.size)
     }
     const fields = result.fields
     if (props.renderBoundaries) {
-      fields.boundary = new Int8Array(plate.fields.size)
+      fields.boundary = new Int8Array(plate.size)
     }
     if (props.renderForces) {
-      fields.forceX = new Float32Array(plate.fields.size)
-      fields.forceY = new Float32Array(plate.fields.size)
-      fields.forceZ = new Float32Array(plate.fields.size)
+      fields.forceX = new Float32Array(plate.size)
+      fields.forceY = new Float32Array(plate.size)
+      fields.forceZ = new Float32Array(plate.size)
     }
     let idx = 0
     plate.fields.forEach(field => {

--- a/js/plates-model/plate-base.js
+++ b/js/plates-model/plate-base.js
@@ -24,6 +24,10 @@ export default class PlateBase {
     return this.angularVelocity.clone().normalize()
   }
 
+  get size () {
+    return this.fields.size
+  }
+
   linearVelocity (absolutePos) {
     return this.angularVelocity.clone().cross(absolutePos)
   }

--- a/js/plates-model/plate-draw-tool.js
+++ b/js/plates-model/plate-draw-tool.js
@@ -8,7 +8,7 @@ export default function plateDrawTool (plate, fieldId, type) {
   distance[fieldId] = 0
   visited[fieldId] = true
 
-  const plateSize = plate.fields.size
+  const plateSize = plate.size
   let continentSize = 0
   if (type === 'continent') {
     plate.fields.forEach(field => {

--- a/js/plates-model/plate.js
+++ b/js/plates-model/plate.js
@@ -130,9 +130,14 @@ export default class Plate extends PlateBase {
   }
 
   addField (props) {
-    const id = props.id
     props.plate = this
     const field = new Field(props)
+    this.addExistingField(field)
+  }
+
+  addExistingField (field) {
+    const id = field.id
+    field.plate = this
     this.fields.set(id, field)
     if (this.adjacentFields.has(id)) {
       this.adjacentFields.delete(id)
@@ -167,8 +172,19 @@ export default class Plate extends PlateBase {
 
   addAdjacentField (id) {
     if (!this.adjacentFields.has(id)) {
-      this.adjacentFields.set(id, new Field({id, plate: this}))
+      const newField = new Field({id, plate: this})
+      if (newField.isAdjacentField()) {
+        this.adjacentFields.set(id, newField)
+      }
     }
+  }
+
+  checkAdjacentFields () {
+    this.adjacentFields.forEach(adjField => {
+      if (!adjField.isAdjacentField()) {
+        console.warn('Buuu', adjField)
+      }
+    })
   }
 
   neighboursCount (absolutePos) {

--- a/js/plates-model/subplate.js
+++ b/js/plates-model/subplate.js
@@ -44,10 +44,6 @@ export default class Subplate extends PlateBase {
     return this.plate.angularVelocity
   }
 
-  get size () {
-    return this.fields.size
-  }
-
   addField (field) {
     const newId = grid.nearestFieldId(this.localPosition(field.absolutePos))
     if (!this.plate.fields.has(newId)) {

--- a/js/plates-model/volcanic-activity.js
+++ b/js/plates-model/volcanic-activity.js
@@ -66,6 +66,7 @@ export default class VolcanicActivity {
 
     if (this.field.isOcean && Math.random() < this.islandProbability * timestep) {
       this.field.type = 'island'
+      this.field.baseElevation += 0.25
       // Make sure that this is still an island. If it's placed next to other islands, their total area
       // might exceed maximal area of the island and we should treat it as a continent.
       markIslands(this.field)

--- a/test/model-serialization.test.js
+++ b/test/model-serialization.test.js
@@ -42,7 +42,7 @@ function comparePlates (p1, p2) {
   expect(p1.invMomentOfInertia).toEqual(p2.invMomentOfInertia)
   expect(p1.density).toEqual(p2.density)
   expect(p1.baseColor).toEqual(p2.baseColor)
-  expect(p1.fields.size).toEqual(p2.fields.size)
+  expect(p1.size).toEqual(p2.size)
   p1.fields.forEach(f1 => {
     const f2 = p2.fields.get(f1.id)
     compareFields(f1, f2)
@@ -59,7 +59,7 @@ function compareSubplates (p1, p2) {
   expect(p1.id).toEqual(p2.id)
   expect(p1.quaternion).toEqual(p2.quaternion)
   expect(p1.angularVelocity).toEqual(p2.angularVelocity)
-  expect(p1.fields.size).toEqual(p2.fields.size)
+  expect(p1.size).toEqual(p2.size)
   p1.fields.forEach(f1 => {
     const f2 = p2.fields.get(f1.id)
     compareFields(f1, f2)


### PR DESCRIPTION
Adds a new config option: `enforceRelativeMotion`. When it's true (default), the model will make sure that there's some relative motion between plates. Also, big plates (bigger than `config. minSizeRatioForDivision`) will be split into two smaller plates.
