### PR TITLE
Fix densities selector

### DIFF
--- a/js/components/sidebar-menu.js
+++ b/js/components/sidebar-menu.js
@@ -47,7 +47,7 @@ export default class SidebarMenu extends PureComponent {
     this.state = {
       saveDialogVisible: false
     }
-    
+
     this.storedPlayState = true
   }
 
@@ -173,7 +173,7 @@ export default class SidebarMenu extends PureComponent {
           {
             OPTION_ENABLED.latLongLines &&
             <ListCheckbox caption='Latitude and longitude lines' legend='Geographic coordinate system'
-              checked={options.renderLatLongLines} onChange={this.toggleLatLongLines}/>
+              checked={options.renderLatLongLines} onChange={this.toggleLatLongLines} />
           }
           {
             OPTION_ENABLED.velocityArrows &&


### PR DESCRIPTION
This PR fixes problem that Sarah has discovered. She had troubles running this URL:
http://models-resources.concord.org/plate-tectonics-3d/branch/master/index.html?planetWizard&planetWizardSteps=%5Bdensities%5D&modelId=03639ca9-8f84-46c0-8b4c-3ae2f893813e&playing=false&crossSection3d=false

`planetWizardSteps=[denisties]` was causing issues as the density selector was the first step.

Console error was easy to fix - JS is complaining about .reduce call without the second argument, as it's called for an empty array. That's fixed by a new helper function `minKey`.

But the component still didn't work after fixing that. The problem was that it was initially called with an empty object (before the model was loaded), and when real properties were set (after the model was loaded) the component didn't update itself.

The main problem was that props processing and state update was done in a constructor. That rarely works, as it means that component won't update itself after setting new properties (and in 99% cases it's a bug). It could work fine if we also implemented `componentWillReceiveProps` and updated state there each time new properties were provided (in the same way as we did in the constructor).

However, the state is not necessary for this component at all - that's the final implementation. It could be useful if we wanted to cache `plateInfos`, but since it's a tiny array (usually < 5 objects), IMHO it makes sense to keep implementation cleaner and more "functional".