### PR TITLE
Reset field properties after changing its type using draw / erase tool

### DIFF
--- a/js/plates-model/plate-draw-tool.js
+++ b/js/plates-model/plate-draw-tool.js
@@ -24,7 +24,10 @@ export default function plateDrawTool (plate, fieldId, type) {
       return
     }
     field.type = type
-    field.baseElevation = type === 'ocean' ? 0.25 : 0.6 + Math.random() * 0.1
+    field.setDefaultProps()
+    if (type === 'continent') {
+      field.baseElevation += 0.1 * Math.random()
+    }
 
     const newDistance = distance[field.id] + Math.random() * 5
     field.forEachNeighbour(otherField => {


### PR DESCRIPTION
It was an obvious bug after ocean depth has been changed. I tried to make sure that in the future we don't have to worry about it. Also, I'm resetting other properties as it seems right and might help with weird effects observed by Amy and Trudi ("phantom plates" after erasing continents).