### PR TITLE
Leaving a border of lower elevation around drawn continents

### DIFF
--- a/js/plates-model/field.js
+++ b/js/plates-model/field.js
@@ -241,6 +241,16 @@ export default class Field extends FieldBase {
     }
   }
 
+  anyNeighbour (condition) {
+    for (let adjId of this.adjacentFields) {
+      const field = this.plate.fields.get(adjId)
+      if (field && condition(field)) {
+        return true
+      }
+    }
+    return false
+  }
+
   // One of the neighbouring fields, pointed by linear velocity vector.
   neighbourAlongVector (direction) {
     const posOfNeighbour = this.absolutePos.clone().add(direction.clone().setLength(grid.fieldDiameter))

--- a/js/plates-model/plate-draw-tool.js
+++ b/js/plates-model/plate-draw-tool.js
@@ -1,25 +1,8 @@
 const MAX_CONTINENTAL_CRUST_RATIO = 0.5
-
-function drawField (field, type, plateSize, continentSize, elevationModifier = 1) {
-  if (type === 'continent' && field.isOcean && (continentSize + 1) / plateSize > MAX_CONTINENTAL_CRUST_RATIO) {
-    return
-  }
-  field.type = type
-  field.setDefaultProps()
-  field.baseElevation *= elevationModifier
-  if (type === 'continent') {
-    field.baseElevation += 0.1 * Math.random()
-  }
-}
+const MAX_DIST = 7
+const SHELF_ELEVATION = 0.48
 
 export default function plateDrawTool (plate, fieldId, type) {
-  const queue = []
-  const visited = {}
-  const distance = {}
-  queue.push(plate.fields.get(fieldId))
-  distance[fieldId] = 0
-  visited[fieldId] = true
-
   const plateSize = plate.size
   let continentSize = 0
   if (type === 'continent') {
@@ -28,28 +11,52 @@ export default function plateDrawTool (plate, fieldId, type) {
         continentSize += 1
       }
     })
+    if ((continentSize + 1) / plateSize > MAX_CONTINENTAL_CRUST_RATIO) {
+      return
+    }
   }
+
+  const queue = []
+  const visited = {}
+  const distance = {}
+  queue.push(plate.fields.get(fieldId))
+  distance[fieldId] = 0
+  visited[fieldId] = true
 
   while (queue.length > 0) {
     const field = queue.shift()
-    drawField(field, type, plateSize, continentSize)
-
-    const newDistance = distance[field.id] + Math.random() * 5
-    field.forEachNeighbour(otherField => {
-      if (!visited[otherField.id]) {
-        if (newDistance < 7) {
+    if (type === 'continent' && field.isOcean) {
+      continentSize += 1
+    }
+    field.type = type
+    field.setDefaultProps()
+    if (type === 'continent') {
+      field.baseElevation += 0.1 * Math.random()
+    }
+    const newDistance = distance[field.id] + 1 + 3 * Math.random()
+    const continentAreaWithinLimit = type === 'ocean' || (continentSize + 1) / plateSize <= MAX_CONTINENTAL_CRUST_RATIO
+    if (newDistance <= MAX_DIST && continentAreaWithinLimit) {
+      field.forEachNeighbour(otherField => {
+        if (!visited[otherField.id]) {
           visited[otherField.id] = true
           distance[otherField.id] = newDistance
           queue.push(otherField)
-        } else {
-          if (type === 'continent' && otherField.type === 'ocean') {
-            drawField(otherField, 'continent', plateSize, continentSize + 1, .7)
-          }
         }
-      }
-      if (visited[otherField.id] && newDistance < distance[otherField.id]) {
-        distance[otherField.id] = newDistance
-      }
-    })
+        if (visited[otherField.id] && newDistance < distance[otherField.id]) {
+          distance[otherField.id] = newDistance
+        }
+      })
+    } else if (type === 'continent' && field.anyNeighbour(otherField => otherField.isOcean)) {
+      // Continent drawing mode. The edge of the continent should have a bit lower elevation, so the transition
+      // between ocean and continent is smooth.
+      field.baseElevation = SHELF_ELEVATION
+    } else if (type === 'ocean') {
+      // Continent erasing mode. The same idea - making sure that the transition between ocean and continent is smooth.
+      field.forEachNeighbour(otherField => {
+        if (otherField.isContinent) {
+          otherField.baseElevation = SHELF_ELEVATION
+        }
+      })
+    }
   }
 }

--- a/js/plates-model/plate-draw-tool.js
+++ b/js/plates-model/plate-draw-tool.js
@@ -1,5 +1,17 @@
 const MAX_CONTINENTAL_CRUST_RATIO = 0.5
 
+function drawField (field, type, plateSize, continentSize, elevationModifier = 1) {
+  if (type === 'continent' && field.isOcean && (continentSize + 1) / plateSize > MAX_CONTINENTAL_CRUST_RATIO) {
+    return
+  }
+  field.type = type
+  field.setDefaultProps()
+  field.baseElevation *= elevationModifier
+  if (type === 'continent') {
+    field.baseElevation += 0.1 * Math.random()
+  }
+}
+
 export default function plateDrawTool (plate, fieldId, type) {
   const queue = []
   const visited = {}
@@ -20,21 +32,20 @@ export default function plateDrawTool (plate, fieldId, type) {
 
   while (queue.length > 0) {
     const field = queue.shift()
-    if (type === 'continent' && field.isOcean && (continentSize + 1) / plateSize > MAX_CONTINENTAL_CRUST_RATIO) {
-      return
-    }
-    field.type = type
-    field.setDefaultProps()
-    if (type === 'continent') {
-      field.baseElevation += 0.1 * Math.random()
-    }
+    drawField(field, type, plateSize, continentSize)
 
     const newDistance = distance[field.id] + Math.random() * 5
     field.forEachNeighbour(otherField => {
-      if (!visited[otherField.id] && newDistance < 7) {
-        visited[otherField.id] = true
-        distance[otherField.id] = newDistance
-        queue.push(otherField)
+      if (!visited[otherField.id]) {
+        if (newDistance < 7) {
+          visited[otherField.id] = true
+          distance[otherField.id] = newDistance
+          queue.push(otherField)
+        } else {
+          if (type === 'continent' && otherField.type === 'ocean') {
+            drawField(otherField, 'continent', plateSize, continentSize + 1, .7)
+          }
+        }
       }
       if (visited[otherField.id] && newDistance < distance[otherField.id]) {
         distance[otherField.id] = newDistance


### PR DESCRIPTION
Relatively simple change - I factored out the logic for drawing a tile, and draw a slightly lower tile on the first tile which is too far to draw an actual continent. This means that the drawn area is now slightly larger than before. I could have lowered the max `distance` from 7 to counteract this, but the behavior seems fine so I did not. 

The only complication was making sure that the max continent to plate ratio was maintained. Right now, you can overwrite the continental shelf once you hit the ratio, but I think that's mostly an edge case