### PR TITLE
There is now a 2-tile boundary of no collisions instead of 1

### DIFF
--- a/js/plates-model/field.js
+++ b/js/plates-model/field.js
@@ -221,6 +221,16 @@ export default class Field extends FieldBase {
     return false
   }
 
+  isBoundaryAdjacent () {
+    for (let adjId of this.adjacentFields) {
+      const field = this.plate.fields.get(adjId)
+      if (field && field.boundary) {
+        return true
+      }
+    }
+    return false
+  }
+
   isAdjacentField () {
     // At least one adjacent field of this field belongs to the plate.
     for (let adjId of this.adjacentFields) {

--- a/js/plates-model/fields-collision.js
+++ b/js/plates-model/fields-collision.js
@@ -36,8 +36,10 @@ function orogeny (bottomField, topField) {
 }
 
 export default function fieldsCollision (bottomField, topField) {
-  if (bottomField.boundary && topField.boundary) {
-    // Skip collision between field at boundary, so simulation looks a bit cleaner.
+  if ((bottomField.boundary && topField.boundary ||
+    (bottomField.boundary && topField.isBoundaryAdjacent()) ||
+    (bottomField.isBoundaryAdjacent() && topField.boundary))) {
+    // Skip boundary/boundary and boundary/boundary-adjacent collisions, so simulation looks a bit cleaner.
     return
   }
 


### PR DESCRIPTION
Here's the "double boundary" change - like I said, it's pretty brute force, let me know if you think it's worth improving e.g. by caching which fields are boundary-adjacent